### PR TITLE
Do not require overriding content block service and page edit view to add content block types

### DIFF
--- a/barebones_cms/models.py
+++ b/barebones_cms/models.py
@@ -76,9 +76,3 @@ class BaseContentBlock(models.Model):
 # Content Blocks
 class SimpleContentBlock(BaseContentBlock):
     content = models.CharField(max_length=255)
-
-
-# Register allowed content blocks by adding them here
-REGISTERED_CONTENT_BLOCKS = [
-    ('Simple Content Block', SimpleContentBlock),
-]

--- a/barebones_cms/services.py
+++ b/barebones_cms/services.py
@@ -159,12 +159,7 @@ class ContentBlockService(object):
         app_config = apps.get_app_config(CMS_APP.split('.')[-1])
         content_block_classes = []
         for model_class in app_config.get_models():
-            is_content_block = issubclass(model_class, BaseContentBlock)
-            # safer to do this by __name__ than comparing the classes
-            # themselves - otherwise projects overriding the abstract
-            # class will have the abstract class appearing also
-            is_base_class = model_class.__name__ == 'BaseContentBlock'
-            if is_content_block and not is_base_class:
+            if issubclass(model_class, BaseContentBlock):
                 class_name = model_class._meta.verbose_name.title()
                 content_type = ContentType.objects.get_for_model(model_class)
                 content_block_classes.append((class_name, content_type.pk))

--- a/barebones_cms/services.py
+++ b/barebones_cms/services.py
@@ -6,6 +6,8 @@ from django.db.models.loading import get_model
 from django.forms import model_to_dict
 from django.apps import apps
 
+from barebones_cms.models import BaseContentBlock
+
 
 # Allow the cms app to be completely overridden with another namespace
 CMS_APP = getattr(settings, 'BB_CMS_APP_NAME', 'apps.cms').split('.')[-1]
@@ -18,7 +20,6 @@ Page = get_model(CMS_APP, 'Page')
 PageTemplate = get_model(CMS_APP, 'PageTemplate')
 Region = get_model(CMS_APP, 'Region')
 ContentBlockLink = get_model(CMS_APP, 'ContentBlockLink')
-BaseContentBlock = get_model(CMS_APP, 'BaseContentBlock')
 
 
 class PageService(object):
@@ -159,7 +160,10 @@ class ContentBlockService(object):
         content_block_classes = []
         for model_class in app_config.get_models():
             is_content_block = issubclass(model_class, BaseContentBlock)
-            is_base_class = model_class is BaseContentBlock
+            # safer to do this by __name__ than comparing the classes
+            # themselves - otherwise projects overriding the abstract
+            # class will have the abstract class appearing also
+            is_base_class = model_class.__name__ == 'BaseContentBlock'
             if is_content_block and not is_base_class:
                 class_name = model_class._meta.verbose_name.title()
                 content_type = ContentType.objects.get_for_model(model_class)

--- a/barebones_cms/services.py
+++ b/barebones_cms/services.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.loading import get_model
 from django.forms import model_to_dict
+from django.apps import apps
 
-from barebones_cms.models import REGISTERED_CONTENT_BLOCKS
 
 # Allow the cms app to be completely overridden with another namespace
 CMS_APP = getattr(settings, 'BB_CMS_APP_NAME', 'apps.cms').split('.')[-1]
@@ -18,6 +18,7 @@ Page = get_model(CMS_APP, 'Page')
 PageTemplate = get_model(CMS_APP, 'PageTemplate')
 Region = get_model(CMS_APP, 'Region')
 ContentBlockLink = get_model(CMS_APP, 'ContentBlockLink')
+BaseContentBlock = get_model(CMS_APP, 'BaseContentBlock')
 
 
 class PageService(object):
@@ -154,7 +155,16 @@ class RegionService(object):
 
 class ContentBlockService(object):
     def get_allowed_content_blocks(self):
-        return [(model[0], ContentType.objects.get_for_model(model[1]).pk) for model in REGISTERED_CONTENT_BLOCKS]
+        app_config = apps.get_app_config(CMS_APP.split('.')[-1])
+        content_block_classes = []
+        for model_class in app_config.get_models():
+            is_content_block = issubclass(model_class, BaseContentBlock)
+            is_base_class = model_class is BaseContentBlock
+            if is_content_block and not is_base_class:
+                class_name = model_class._meta.verbose_name.title()
+                content_type = ContentType.objects.get_for_model(model_class)
+                content_block_classes.append((class_name, content_type.pk))
+        return content_block_classes
 
     def get_contentblock_model(self, content_type):
         content_type = ContentType.objects.get(pk=content_type)


### PR DESCRIPTION
Service was always importing REGISTERED_CONTENT_BLOCKS from barebones_cms, so it was impossible to override.
